### PR TITLE
Update release workflow to use new signing identities

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,9 +56,13 @@ jobs:
 
     - name: 'Verify Redis Image Signature && pre-pull image'
       run: |
+        # Images will be signed by either the CATALOG_SYNCER or APKO_BUILDER identity in your organization.
+        # To find these values for your organization, you can view the "Assumed Identities" page in your organization settings.
+        CATALOG_SYNCER="4cf15780a13a9b6576d8b357e6524554c8c12a18/c03040118377d88c"
+        APKO_BUILDER="4cf15780a13a9b6576d8b357e6524554c8c12a18/ca93125e202f81f8"
         cosign verify \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-            --certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+            --certificate-oidc-issuer=https://issuer.enforce.dev \
+            --certificate-identity-regexp="https://issuer.enforce.dev/(${CATALOG_SYNCER}|${APKO_BUILDER})" \
             ${{ env.REDIS_IMAGE_FULL_REF }} | jq        
         docker pull ${{ env.REDIS_IMAGE_FULL_REF }}
     


### PR DESCRIPTION
Updating workflow to use new signing identities as described in [our docs](https://edu.chainguard.dev/chainguard/chainguard-images/how-to-use/verifying-chainguard-images-and-metadata-signatures-with-cosign/). I'm using hard-coded values (which will not change) rather than fetching them dynamically with `chainctl `so that the workflow doesn't need to granted any more permissions.